### PR TITLE
code: implement InjectContext marker function

### DIFF
--- a/marker.go
+++ b/marker.go
@@ -13,16 +13,25 @@
 
 package failpoint
 
+import "context"
+
 // Inject marks a fail point routine, which will be rewrite to a `if` statement
 // and be triggered by fail point name specified `fpname`
-// Note: The fail point closure  parameter type can only be `context.Context` or `failpoint.Value`
+// Note: The fail point closure  parameter type can only be `failpoint.Value`
 // e.g:
 // failpoint.Inject("fail-point-name", func() (...){}
 // failpoint.Inject("fail-point-name", func(val failpoint.Value) (...){}
-// failpoint.Inject("fail-point-name", func(ctx context.Context) (...){}
-// failpoint.Inject("fail-point-name", func(ctx context.Context, val failpoint.Value) (...){}
-// failpoint.Inject("fail-point-name", func(val failpoint.Value, ctx context.Context) (...){}
+// failpoint.Inject("fail-point-name", func(_ failpoint.Value) (...){}
 func Inject(fpname string, fpbody interface{}) {}
+
+// InjectContext marks a fail point routine, which will be rewrite to a `if` statement
+// and be triggered by fail point name specified `fpname`
+// Note: The fail point closure  parameter type can only be `failpoint.Value`
+// e.g:
+// failpoint.InjectContext("fail-point-name", ctx, func() (...){}
+// failpoint.InjectContext("fail-point-name", ctx, func(val failpoint.Value) (...){}
+// failpoint.InjectContext("fail-point-name", ctx, func(_ failpoint.Value) (...){}
+func InjectContext(fpname string, ctx context.Context, fpbody interface{}) {}
 
 // Break will generate a break statement in a loop, e.g:
 // case1:


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`failpoint.Inject` is the only way to inject a closure as a failpoint to out program in the before implementation, which drawback is the context parameter name has some limit and can not use compiler check in the regular mode.

### What is changed and how it works?

Add a new `failpoint.InjectContext` marker function to fix this.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

N/A

Related changes

N/A