### PR TITLE
code: fix default case in select statement rewrite

### DIFF
--- a/code/rewriter.go
+++ b/code/rewriter.go
@@ -329,12 +329,15 @@ func (r *Rewriter) rewriteStmts(stmts []ast.Stmt) error {
 			// case <- fromCh:
 			// case toCh <- x:
 			// case <- func() chan bool {...}():
+			// default:
 			// }
-			sendOrRecv := v.Comm.(*ast.ExprStmt).X.(*ast.UnaryExpr)
-			if callExpr, ok := sendOrRecv.X.(*ast.CallExpr); ok {
-				err := r.rewriteCallExpr(callExpr)
-				if err != nil {
-					return err
+			if v.Comm != nil {
+				sendOrRecv := v.Comm.(*ast.ExprStmt).X.(*ast.UnaryExpr)
+				if callExpr, ok := sendOrRecv.X.(*ast.CallExpr); ok {
+					err := r.rewriteCallExpr(callExpr)
+					if err != nil {
+						return err
+					}
 				}
 			}
 			err := r.rewriteStmts(v.Body)

--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -1051,6 +1051,10 @@ func unittest() {
 		failpoint.Inject("failpoint-name", func(val failpoint.Value) {
 			fmt.Println("unit-test", val)
 		})
+	default:
+		failpoint.Inject("failpoint-name", func(val failpoint.Value) {
+			fmt.Println("unit-test", val)
+		})
 	}
 }
 `,
@@ -1082,6 +1086,10 @@ func unittest() {
 		}
 		return make(chan bool)
 	}():
+		if ok, val := failpoint.Eval("failpoint-name"); ok {
+			fmt.Println("unit-test", val)
+		}
+	default:
 		if ok, val := failpoint.Eval("failpoint-name"); ok {
 			fmt.Println("unit-test", val)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
panic from the following code snippet.

```
package main

import (
    "fmt"

    "github.com/pingcap/failpoint"
)

func main() {
    select {
    default:
        failpoint.Inject("fptest", func() {
            fmt.Printf("in fp test...\n")
        })
    }
}
```

```
panic: interface conversion: ast.Stmt is nil, not *ast.ExprStmt

To see all goroutines, visit https://github.com/maruel/panicparse#gotraceback

1: running
    code rewriter.go:333 (*Rewriter).rewriteStmts(#1, 0xc0000683f0, 0x1, 0x1, 0x74, 0x1)
    code rewriter.go:349 (*Rewriter).rewriteStmts(#1, 0xc000068410, 0x1, 0x1, 0xc00009a0c1, 0x1c)
    code rewriter.go:411 (*Rewriter).rewriteFuncDecl(...)
    code rewriter.go:447 (*Rewriter).rewriteFile(#1, 0xc0000961b0, 0x2d, 0, 0)
    code rewriter.go:516 (*Rewriter).Rewrite(#1, #1, 0)
    main main.go:67      main()
```

### What is changed and how it works?
check whether `send or receive statement` is not nil in `CommClause` before rewriting it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
