### PR TITLE
code: auto extend failpoint name with package name

### DIFF
--- a/code/expr_rewriter.go
+++ b/code/expr_rewriter.go
@@ -80,12 +80,17 @@ func (r *Rewriter) rewriteInject(call *ast.CallExpr) (bool, ast.Stmt, error) {
 		argName = ast.NewIdent("_")
 	}
 
+	fpnameExtendCall := &ast.CallExpr{
+		Fun:  &ast.Ident{Name: extendPkgName},
+		Args: []ast.Expr{fpname},
+	}
+
 	checkCall = &ast.CallExpr{
 		Fun: &ast.SelectorExpr{
 			X:   &ast.Ident{Name: r.failpointName},
 			Sel: &ast.Ident{Name: evalFunction},
 		},
-		Args: []ast.Expr{fpname},
+		Args: []ast.Expr{fpnameExtendCall},
 	}
 	init = &ast.AssignStmt{
 		Lhs: []ast.Expr{cond, argName},
@@ -154,12 +159,17 @@ func (r *Rewriter) rewriteInjectContext(call *ast.CallExpr) (bool, ast.Stmt, err
 		argName = ast.NewIdent("_")
 	}
 
+	fpnameExtendCall := &ast.CallExpr{
+		Fun:  &ast.Ident{Name: extendPkgName},
+		Args: []ast.Expr{fpname},
+	}
+
 	checkCall = &ast.CallExpr{
 		Fun: &ast.SelectorExpr{
 			X:   &ast.Ident{Name: r.failpointName},
 			Sel: &ast.Ident{Name: evalFunction},
 		},
-		Args: []ast.Expr{fpname, ctxname},
+		Args: []ast.Expr{fpnameExtendCall, ctxname},
 	}
 
 	init = &ast.AssignStmt{

--- a/code/restorer.go
+++ b/code/restorer.go
@@ -14,6 +14,8 @@
 package code
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,6 +23,7 @@ import (
 
 const (
 	failpointStashFileSuffix = "__failpoint_stash__"
+	failpointBindingFileName = "binding__failpoint_binding__.go"
 )
 
 type Restorer struct {
@@ -60,7 +63,8 @@ func (r Restorer) Restore() error {
 		if info.IsDir() {
 			return nil
 		}
-		if strings.HasSuffix(path, failpointStashFileSuffix) {
+		if strings.HasSuffix(path, failpointStashFileSuffix) ||
+			strings.HasSuffix(path, failpointBindingFileName) {
 			stashFiles = append(stashFiles, path)
 		}
 		return nil
@@ -69,6 +73,12 @@ func (r Restorer) Restore() error {
 		return err
 	}
 	for _, filePath := range stashFiles {
+		if strings.HasSuffix(filePath, failpointBindingFileName) {
+			if err := os.Remove(filePath); err != nil {
+				return err
+			}
+			continue
+		}
 		originFileName := filePath[:len(filePath)-len(failpointStashFileSuffix)]
 		if err := os.Remove(originFileName); err != nil {
 			return err
@@ -78,4 +88,32 @@ func (r Restorer) Restore() error {
 		}
 	}
 	return nil
+}
+
+func failpointBindingPath(path string) string {
+	return filepath.Join(filepath.Dir(path), failpointBindingFileName)
+}
+
+func isBindingFileExists(path string) (bool, error) {
+	bindingFile := failpointBindingPath(path)
+	_, err := os.Stat(bindingFile)
+	if err != nil && os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
+}
+
+func writeBindingFile(path, pak string) error {
+	bindingFile := failpointBindingPath(path)
+	bindingContent := fmt.Sprintf(`
+package %s
+
+import "reflect"
+
+type __failpointBindingType struct {}
+func %s(name string) string {
+	return reflect.TypeOf(__failpointBindingType{}).PkgPath() + "/" + name
+}
+`, pak, extendPkgName)
+	return ioutil.WriteFile(bindingFile, []byte(bindingContent), os.ModePerm)
 }

--- a/code/restorer.go
+++ b/code/restorer.go
@@ -110,9 +110,14 @@ package %s
 
 import "reflect"
 
-type __failpointBindingType struct {}
+type __failpointBindingType struct {pkgpath string}
+var __failpointBindingCache = &__failpointBindingType{}
+
+func init() {
+	__failpointBindingCache.pkgpath = reflect.TypeOf(__failpointBindingType{}).PkgPath()
+}
 func %s(name string) string {
-	return reflect.TypeOf(__failpointBindingType{}).PkgPath() + "/" + name
+	return  __failpointBindingCache.pkgpath + "/" + name
 }
 `, pak, extendPkgName)
 	return ioutil.WriteFile(bindingFile, []byte(bindingContent), os.ModePerm)

--- a/code/rewriter.go
+++ b/code/rewriter.go
@@ -21,13 +21,15 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 )
 
 const (
-	packagePath  = "github.com/pingcap/failpoint"
-	packageName  = "failpoint"
-	evalFunction = "Eval"
+	packagePath   = "github.com/pingcap/failpoint"
+	packageName   = "failpoint"
+	evalFunction  = "Eval"
+	extendPkgName = "_curpkg_"
 )
 
 type Rewriter struct {
@@ -436,7 +438,12 @@ func (r *Rewriter) rewriteFuncDecl(fn *ast.FuncDecl) error {
 	return r.rewriteStmts(fn.Body.List)
 }
 
-func (r *Rewriter) rewriteFile(path string) error {
+func (r *Rewriter) rewriteFile(path string) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = fmt.Errorf("%v\n%s", e, debug.Stack())
+		}
+	}()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 	if err != nil {
@@ -478,6 +485,18 @@ func (r *Rewriter) rewriteFile(path string) error {
 		return nil
 	}
 
+	// Generate binding code
+	found, err := isBindingFileExists(path)
+	if err != nil {
+		return err
+	}
+	if !found {
+		err := writeBindingFile(path, file.Name.Name)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Backup origin file and replace content
 	targetPath := path + failpointStashFileSuffix
 	if err := os.Rename(path, targetPath); err != nil {
@@ -502,6 +521,9 @@ func (r *Rewriter) Rewrite() error {
 			return nil
 		}
 		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if strings.HasSuffix(path, failpointBindingFileName) {
 			return nil
 		}
 		// Will rewrite a file only if the file has imported "github.com/pingcap/failpoint"

--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -67,7 +67,7 @@ import (
 )
 
 func unittest() {
-	if ok, val := failpoint.Eval("failpoint-name"); ok {
+	if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 		fmt.Println("unit-test", val)
 	}
 }
@@ -101,7 +101,7 @@ import (
 )
 
 func unittest() {
-	if ok, _ := failpoint.Eval("failpoint-name"); ok {
+	if ok, _ := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 		fmt.Println("unit-test")
 	}
 }
@@ -135,7 +135,7 @@ import (
 )
 
 func unittest() {
-	if ok, _ := failpoint.Eval("failpoint-name"); ok {
+	if ok, _ := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 		fmt.Println("unit-test")
 	}
 }
@@ -175,7 +175,7 @@ import (
 var ctx = context.Background()
 
 func unittest() {
-	if ok, val := failpoint.Eval("failpoint-name", ctx); ok {
+	if ok, val := failpoint.Eval(_curpkg_("failpoint-name"), ctx); ok {
 		fmt.Println("unit-test", val)
 	}
 }
@@ -211,7 +211,7 @@ import (
 )
 
 func unittest() {
-	if ok, val := failpoint.Eval("failpoint-name", nil); ok {
+	if ok, val := failpoint.Eval(_curpkg_("failpoint-name"), nil); ok {
 		fmt.Println("unit-test", val)
 	}
 }
@@ -247,7 +247,7 @@ import (
 )
 
 func unittest() {
-	if ok, _ := failpoint.Eval("failpoint-name", nil); ok {
+	if ok, _ := failpoint.Eval(_curpkg_("failpoint-name"), nil); ok {
 		fmt.Println("unit-test")
 	}
 }
@@ -290,11 +290,11 @@ import (
 
 func unittest() {
 	var _, f1, f2 = 10, func() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}, func() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}
@@ -340,11 +340,11 @@ import (
 
 func unittest() {
 	_, f1, f2 := 10, func() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}, func() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}
@@ -384,7 +384,7 @@ import (
 
 func unittest() {
 	go func() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}()
@@ -426,11 +426,11 @@ import (
 
 func unittest() {
 	go func(_ func()) {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}(func() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	})
@@ -468,7 +468,7 @@ import (
 
 func unittest() {
 	defer func() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}()
@@ -510,11 +510,11 @@ import (
 
 func unittest() {
 	defer func(_ func()) {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}(func() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	})
@@ -557,11 +557,11 @@ import (
 
 func unittest() {
 	return func() (func(), int) {
-			if ok, val := failpoint.Eval("failpoint-name"); ok {
+			if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 				fmt.Println("unit-test", val)
 			}
 		}, func() int {
-			if ok, val := failpoint.Eval("failpoint-name"); ok {
+			if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 				fmt.Println("unit-test", val)
 			}
 			return 1000
@@ -612,15 +612,15 @@ import (
 func unittest() {
 	x := rand.Float32()
 	if x > 0.5 {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	} else if x > 0.2 {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	} else {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}
@@ -665,12 +665,12 @@ import (
 
 func unittest() {
 	if a, b := func() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}, func() int { return rand.Intn(200) }(); b > 100 {
 		a()
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}
@@ -725,22 +725,22 @@ import (
 
 func unittest() {
 	if a, b := func() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}, func() int { return rand.Intn(200) }(); b > func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(3000)
 	}() && b < func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(6000)
 	}() {
 		a()
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}
@@ -806,33 +806,33 @@ import (
 
 func unittest() {
 	switch x, y := rand.Intn(10), func() int { return rand.Intn(1000) }(); x - y + func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(50)
 	}() {
 	case func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(5)
 	}(), func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(8)
 	}():
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	default:
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}
@@ -903,36 +903,36 @@ import (
 
 func unittest() {
 	switch x, y := rand.Intn(10), func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(1000)
 	}(); func(x, y int) int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(50) + x + y
 	}(x, y) {
 	case func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(5)
 	}(), func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(8)
 	}():
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	default:
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		fn := func() {
-			if ok, val := failpoint.Eval("failpoint-name"); ok {
+			if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 				fmt.Println("unit-test", val)
 			}
 		}
@@ -1006,37 +1006,37 @@ import (
 func unittest() {
 	select {
 	case ch := <-func() chan bool {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return make(chan bool)
 	}():
 		fmt.Println(ch)
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 
 	case <-func() chan bool {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return make(chan bool)
 	}():
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 
 	case <-func() chan bool {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return make(chan bool)
 	}():
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	default:
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}
@@ -1091,22 +1091,22 @@ import (
 
 func unittest() {
 	for i := func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(100)
 	}(); i < func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(10000)
 	}(); i += func() int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return rand.Intn(100)
 	}() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 	}
@@ -1157,16 +1157,16 @@ import (
 
 func unittest() {
 	for x, y := range func() map[int]int {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		return make(map[int]int, rand.Intn(10))
 	}() {
-		if ok, val := failpoint.Eval("failpoint-name"); ok {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 			fmt.Println("unit-test", val)
 		}
 		fn := func() {
-			if ok, val := failpoint.Eval("failpoint-name"); ok {
+			if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 				fmt.Println("unit-test", val, x, y)
 			}
 		}
@@ -1257,7 +1257,7 @@ outer:
 			case j / 10:
 				goto outer
 			default:
-				if ok, val := failpoint.Eval("failpoint-name"); ok {
+				if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 					fmt.Println("unit-test", val.(int))
 					if val == j/11 {
 						goto inner


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Will auto extend failpoint name with package name. For example,

```go
pacakge ddl // which contains in project github.com/pingcap/tidb

func createTable() {
	failpoint.Inject("createTableErr"), func() {...})
}
```

The name will auto extend to `github.com/pingcap/tidb/ddl/createTableErr`

### What is changed and how it works?

Rewrite some rules

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

N/A

Related changes

N/A