### PR TITLE
code: fix assign case in select rewrite

### DIFF
--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -956,6 +956,17 @@ import (
 
 func unittest() {
 	select {
+	case ch := <-func() chan bool {
+		failpoint.Inject("failpoint-name", func(val failpoint.Value) {
+			fmt.Println("unit-test", val)
+		})
+		return make(chan bool)
+	}():
+		fmt.Println(ch)
+		failpoint.Inject("failpoint-name", func(val failpoint.Value) {
+			fmt.Println("unit-test", val)
+		})
+
 	case <-func() chan bool {
 		failpoint.Inject("failpoint-name", func(val failpoint.Value) {
 			fmt.Println("unit-test", val)
@@ -994,6 +1005,17 @@ import (
 
 func unittest() {
 	select {
+	case ch := <-func() chan bool {
+		if ok, val := failpoint.Eval("failpoint-name"); ok {
+			fmt.Println("unit-test", val)
+		}
+		return make(chan bool)
+	}():
+		fmt.Println(ch)
+		if ok, val := failpoint.Eval("failpoint-name"); ok {
+			fmt.Println("unit-test", val)
+		}
+
 	case <-func() chan bool {
 		if ok, val := failpoint.Eval("failpoint-name"); ok {
 			fmt.Println("unit-test", val)
@@ -1274,7 +1296,7 @@ outer:
 		expected := filepath.Join(s.path, cs.filepath)
 		content, err := ioutil.ReadFile(expected)
 		c.Assert(err, Equals, nil)
-		c.Assert(strings.TrimSpace(cs.expected), Equals, strings.TrimSpace(string(content)))
+		c.Assert(strings.TrimSpace(string(content)), Equals, strings.TrimSpace(cs.expected))
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
rewrite will fail if we have an assign statement in `select case`, such as the following code snippet
```
select {
case ch := <-func() chan bool {
    failpoint.Inject("fptest", func() {
        fmt.Printf("in fp test...\n")
    })
    return make(chan bool)
}():
    fmt.Printf("recv ch %v\n", ch)
}
```

### What is changed and how it works?
1. if `*ast.CommClause.Comm` is `*ast.AssignStmt`, apply `rewriteAssign` to it
2. the right-hand statement of an `AssignStmt` can be an `*ast.UnaryExpr`, rewrite it as possible
3. fix parameter sequence of `c.Assert`, as the function is declared as `func (c *C) Assert(obtained interface{}, checker Checker, args ...interface{})`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test