### PR TITLE
code: refactor expression rewriter and support SendStmt and LabelStmt

### DIFF
--- a/code/expr_rewriter.go
+++ b/code/expr_rewriter.go
@@ -256,7 +256,7 @@ func (r *Rewriter) rewriteLabel(call *ast.CallExpr) (bool, ast.Stmt, error) {
 	label = strings.Trim(label, "`\"")
 	stmt := &ast.LabeledStmt{
 		Colon: call.Pos(),
-		Label: ast.NewIdent(label),
+		Label: ast.NewIdent(label + labelSuffix), // It's a trick here
 	}
 	return true, stmt, nil
 }

--- a/code/rewriter.go
+++ b/code/rewriter.go
@@ -33,7 +33,7 @@ const (
 	extendPkgName   = "_curpkg_"
 	// It is an indicator to indicate the label is converted from `failpoint.Label("...")`
 	// We use an illegal suffix to avoid conflict with the user's code
-	// So `failpoint.Label(""label1")` will be converted to `label1-tmp-marker:` in expression
+	// So `failpoint.Label("label1")` will be converted to `label1-tmp-marker:` in expression
 	// rewrite and be converted to the legal form in label statement organization.
 	labelSuffix = "-tmp-marker"
 )
@@ -501,7 +501,6 @@ func (r *Rewriter) rewriteStmts(stmts []ast.Stmt) error {
 		stmt := stmts[i]
 		if label, ok := stmt.(*ast.LabeledStmt); ok && strings.HasSuffix(label.Label.Name, labelSuffix) {
 			label.Label.Name = label.Label.Name[:len(label.Label.Name)-len(labelSuffix)]
-			fmt.Println(r.pos(label.Pos()), i, len(stmts))
 			label.Stmt = stmts[i+1]
 			stmts[i+1] = &ast.EmptyStmt{}
 		}

--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -1669,7 +1669,7 @@ func (s *rewriterSuite) TestRewriteBad(c *C) {
 
 		{
 			filepath: "bad-basic-test.go",
-			errormsg: `failpoint\.Inject: invalid signature with type.*`,
+			errormsg: `failpoint\.Inject: invalid signature.*`,
 			original: `
 package rewriter_test
 
@@ -1729,7 +1729,7 @@ func unittest() {
 
 		{
 			filepath: "bad-basic-test4.go",
-			errormsg: `failpoint\.Inject: expect 2 arguments but got 3`,
+			errormsg: `failpoint\.Inject: expect 2 arguments but got 3.*`,
 			original: `
 package rewriter_test
 
@@ -1789,7 +1789,7 @@ func unittest() {
 
 		{
 			filepath: "bad-basic-test6.go",
-			errormsg: `failpoint\.Inject: first argument expect string literal but got.*`,
+			errormsg: `failpoint\.Inject: first argument expect string literal in.*`,
 			original: `
 package rewriter_test
 
@@ -1809,7 +1809,7 @@ func unittest() {
 
 		{
 			filepath: "bad-basic-test7.go",
-			errormsg: `failpoint\.Inject: second argument expect closure but got.*`,
+			errormsg: `failpoint\.Inject: second argument expect closure in.*`,
 			original: `
 package rewriter_test
 
@@ -1827,7 +1827,7 @@ func unittest() {
 
 		{
 			filepath: "bad-basic-ctx-test1.go",
-			errormsg: `failpoint\.InjectContext: expect 3 arguments but got 4`,
+			errormsg: `failpoint\.InjectContext: expect 3 arguments but got 4.*`,
 			original: `
 package rewriter_test
 
@@ -1847,7 +1847,7 @@ func unittest() {
 
 		{
 			filepath: "bad-basic-ctx-test2.go",
-			errormsg: `failpoint\.InjectContext: first argument expect context but go.*`,
+			errormsg: `failpoint\.InjectContext: first argument expect context in.*`,
 			original: `
 package rewriter_test
 
@@ -1867,7 +1867,7 @@ func unittest() {
 
 		{
 			filepath: "bad-basic-ctx-test3.go",
-			errormsg: `failpoint\.InjectContext: second argument expect string literal but got.*`,
+			errormsg: `failpoint\.InjectContext: second argument expect string literal in.*`,
 			original: `
 package rewriter_test
 
@@ -1887,7 +1887,7 @@ func unittest() {
 
 		{
 			filepath: "bad-basic-ctx-test4.go",
-			errormsg: `failpoint\.InjectContext: third argument expect closure but got.*`,
+			errormsg: `failpoint\.InjectContext: third argument expect closure in.*`,
 			original: `
 package rewriter_test
 

--- a/failpoint-ctl/main.go
+++ b/failpoint-ctl/main.go
@@ -65,7 +65,7 @@ func main() {
 			rewritePath = append(rewritePath, path)
 			rewriter := code.NewRewriter(path)
 			if err := rewriter.Rewrite(); err != nil {
-				fmt.Println("Error occurred in rewriting path " + path + " with " + err.Error())
+				fmt.Println("Rewrite error " + err.Error())
 				errOccurred = true
 				break
 			}
@@ -91,7 +91,7 @@ func restoreFiles(paths []string) {
 		restorer := code.NewRestorer(paths[i])
 		err := restorer.Restore()
 		if err != nil {
-			fmt.Println("Error occurred in restore " + paths[i] + " with " + err.Error())
+			fmt.Println("Restore error " + err.Error())
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Refactor expression rewriter and add support for `SendStmt` and `LabelStmt`

### What is changed and how it works?

1. Move expression rewrite related function to `rewriteExpr` function to reduce complexity.
2. Add support for `SendStmt` and `LabelStmt`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

N/A

Related changes

N/A