### PR TITLE
code: add support for failpoint.Inject("failpoint-name", nil) and Return marker function

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ An implementation of [failpoints][failpoint] for Golang.
     - `func Goto(label string) {}`
     - `func Continue(label ...string) {}`
     - `func Fallthrough() {}`
+    - `func Return(results ...interface{}) {}`
     - `func Label(label string) {}`
 
 ## How to inject a failpoint to your program
@@ -67,7 +68,7 @@ used to trigger the failpoint and `failpoint-closure` will be expanded as the bo
 
     ```go
     failpoint.Inject("failpoint-name", func(val failpoint.Value) {
-        fmt.Println("unit-test", val)
+        failpoint.Return("unit-test", val)
     })
     ```
 
@@ -75,7 +76,7 @@ used to trigger the failpoint and `failpoint-closure` will be expanded as the bo
 
     ```go
     if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
-        fmt.Println("unit-test", val)
+        return "unit-test", val
     }
     ```
 

--- a/code/expr_rewriter.go
+++ b/code/expr_rewriter.go
@@ -28,8 +28,9 @@ var exprRewriters = map[string]exprRewriter{
 	"Break":         (*Rewriter).rewriteBreak,
 	"Continue":      (*Rewriter).rewriteContinue,
 	"Label":         (*Rewriter).rewriteLabel,
-	"Goto":          (*Rewriter).rewroteGoto,
-	"Fallthrough":   (*Rewriter).rewroteFallthrough,
+	"Goto":          (*Rewriter).rewriteGoto,
+	"Fallthrough":   (*Rewriter).rewriteFallthrough,
+	"Return":        (*Rewriter).rewriteReturn,
 }
 
 func (r *Rewriter) rewriteInject(call *ast.CallExpr) (bool, ast.Stmt, error) {
@@ -259,7 +260,7 @@ func (r *Rewriter) rewriteLabel(call *ast.CallExpr) (bool, ast.Stmt, error) {
 	return true, stmt, nil
 }
 
-func (r *Rewriter) rewroteGoto(call *ast.CallExpr) (bool, ast.Stmt, error) {
+func (r *Rewriter) rewriteGoto(call *ast.CallExpr) (bool, ast.Stmt, error) {
 	if count := len(call.Args); count != 1 {
 		return false, nil, fmt.Errorf("failpoint.Goto expect 1 arguments, but got %v in %s", count, r.pos(call.Pos()))
 	}
@@ -273,10 +274,18 @@ func (r *Rewriter) rewroteGoto(call *ast.CallExpr) (bool, ast.Stmt, error) {
 	return true, stmt, nil
 }
 
-func (r *Rewriter) rewroteFallthrough(call *ast.CallExpr) (bool, ast.Stmt, error) {
+func (r *Rewriter) rewriteFallthrough(call *ast.CallExpr) (bool, ast.Stmt, error) {
 	stmt := &ast.BranchStmt{
 		TokPos: call.Pos(),
 		Tok:    token.FALLTHROUGH,
+	}
+	return true, stmt, nil
+}
+
+func (r *Rewriter) rewriteReturn(call *ast.CallExpr) (bool, ast.Stmt, error) {
+	stmt := &ast.ReturnStmt{
+		Return:  call.Pos(),
+		Results: call.Args,
 	}
 	return true, stmt, nil
 }

--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -1841,6 +1841,66 @@ func unittest() {
 }
 `,
 		},
+
+		{
+			filepath: "test-nil-closure.go",
+			original: `
+package rewriter_test
+
+import (
+	"fmt"
+
+	"github.com/pingcap/failpoint"
+)
+
+func unittest() {
+	failpoint.Inject("failpoint-name", nil)
+}
+`,
+			expected: `
+package rewriter_test
+
+import (
+	"fmt"
+
+	"github.com/pingcap/failpoint"
+)
+
+func unittest() {
+	failpoint.Eval(_curpkg_("failpoint-name"))
+}
+`,
+		},
+
+		{
+			filepath: "test-nil-closure-ctx.go",
+			original: `
+package rewriter_test
+
+import (
+	"fmt"
+
+	"github.com/pingcap/failpoint"
+)
+
+func unittest() {
+	failpoint.InjectContext(nil, "failpoint-name", nil)
+}
+`,
+			expected: `
+package rewriter_test
+
+import (
+	"fmt"
+
+	"github.com/pingcap/failpoint"
+)
+
+func unittest() {
+	failpoint.EvalContext(nil, _curpkg_("failpoint-name"))
+}
+`,
+		},
 	}
 
 	// Create temp files

--- a/marker.go
+++ b/marker.go
@@ -67,6 +67,9 @@ func Continue(label ...string) {}
 // Fallthrough will translate to a `fallthrough` statement
 func Fallthrough() {}
 
+// Return will translate to a `return` statement
+func Return(result ...interface{}) {}
+
 // Label will generate a label statement, e.g.
 // case1:
 //   failpoint.Label("outer")


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- Support nil closure

	If we want a failpoint just sleep a duration like `failpoint.Enable("failpoint-name", "sleep(500))`, we must use a function without any statements and that will cause generated code line inconsistent.
	
	In following case:
	
	```go
	failpoint.Inject("failpoint-name", func(){})
	```
	
	Will generate:
	
	```go
	if ok, _ := failpoint.Eval(_curpkg_("failpoint-name")); ok {
	}
	```

- Add `Return` marker function

	```go
	func foo() (int, string) {
		// Some logic
		failpoint.Inject("failpoint-name", func(val failpoint.Value) (int, string) {
			// return early
			if val.(int) % 10 == 0 {
				return val.(int), "string from failpoint"
			}
			// We must write a return statement here to make the program legal
			return 0, "I do not want return anything here"
		})
		// Other logics
	}
	```
	
	If we need an `early return` in failpoint with some conditions like above case. We will get unexpected result because there is always `early return` if failpoint is active. So we need a `Return` marker function.
	
	```go
	func foo() (int, string) {
		// Some logic
		failpoint.Inject("failpoint-name", func(val failpoint.Value) {
			// return early
			if val.(int) % 10 == 0 {
				failpoint.Return(val.(int), "string from failpoint")
			}
		})
		// Other logics
	}
	```

### What is changed and how it works?

Add support for nil closure, which will generate a `failpoint.Eval(...)` call instead of an IF statement.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

N/A

Related changes

N/A