### PR TITLE
code: support rewrite ExprStmt Init in forStmt

### DIFF
--- a/code/rewriter.go
+++ b/code/rewriter.go
@@ -414,17 +414,15 @@ func (r *Rewriter) rewriteStmts(stmts []ast.Stmt) error {
 		case *ast.ForStmt:
 			// for i := func() int {...}(); i < func() int {...}(); i += func() int {...}() {...}
 			if v.Init != nil {
-				if expr, ok := v.Init.(*ast.ExprStmt); ok {
-					err := r.rewriteExpr(expr.X)
-					if err != nil {
-						return err
-					}
+				var err error
+				switch stmt := v.Init.(type) {
+				case *ast.ExprStmt:
+					err = r.rewriteExpr(stmt.X)
+				case *ast.AssignStmt:
+					err = r.rewriteAssign(stmt)
 				}
-				if assign, ok := v.Init.(*ast.AssignStmt); ok {
-					err := r.rewriteAssign(assign)
-					if err != nil {
-						return err
-					}
+				if err != nil {
+					return err
 				}
 			}
 			if v.Cond != nil {

--- a/code/rewriter.go
+++ b/code/rewriter.go
@@ -414,9 +414,17 @@ func (r *Rewriter) rewriteStmts(stmts []ast.Stmt) error {
 		case *ast.ForStmt:
 			// for i := func() int {...}(); i < func() int {...}(); i += func() int {...}() {...}
 			if v.Init != nil {
-				err := r.rewriteAssign(v.Init.(*ast.AssignStmt))
-				if err != nil {
-					return err
+				if expr, ok := v.Init.(*ast.ExprStmt); ok {
+					err := r.rewriteExpr(expr.X)
+					if err != nil {
+						return err
+					}
+				}
+				if assign, ok := v.Init.(*ast.AssignStmt); ok {
+					err := r.rewriteAssign(assign)
+					if err != nil {
+						return err
+					}
 				}
 			}
 			if v.Cond != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
initialization statement in for loop could be an `ast.ExprStmt`, such as following code snippet

```go
package hello

import (
        "fmt"

        "github.com/pingcap/failpoint"
)

type Iterator struct {
        count int
        max   int
}

func (i *Iterator) Begin(fn func()) int {
        i.count = 0
        return i.count
}

func (i *Iterator) Next() int {
        if i.count >= i.max {
                panic("iterator to end")
        }
        i.count++
        return i.count
}

func (i *Iterator) End() bool {
        return i.count == i.max
}

func Hello() {
        iter := &Iterator{max: 10}
        for iter.Begin(func() {
                failpoint.Inject("fptest-in-pkg", func(val failpoint.Value) {
                        fmt.Printf("inject value: %v\n", val)
                })
        }); !iter.End(); {
                i := iter.Next()
                fmt.Printf("get value: %d\n", i)
        }
}
```

### What is changed and how it works?
add support to it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test