### PR TITLE
code: add support for ast.IncDecStmt

### DIFF
--- a/code/rewriter.go
+++ b/code/rewriter.go
@@ -524,7 +524,7 @@ func (r *Rewriter) rewriteStmts(stmts []ast.Stmt) error {
 			// ignore keyword token (BREAK, CONTINUE, GOTO, FALLTHROUGH)
 
 		default:
-			fmt.Printf("unsupport statement: %T in %s\n", v, r.pos(v.Pos()))
+			fmt.Printf("unsupported statement: %T in %s\n", v, r.pos(v.Pos()))
 		}
 	}
 
@@ -561,6 +561,7 @@ func (r *Rewriter) rewriteFile(path string) (err error) {
 	r.currentPath = path
 	r.currentFile = file
 	r.currsetFset = fset
+	r.rewritten = false
 
 	var failpointImport *ast.ImportSpec
 	for _, imp := range file.Imports {

--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -977,7 +977,7 @@ func unittest() {
 			failpoint.Inject("failpoint-name", func(val failpoint.Value) {
 				fmt.Println("unit-test", val)
 			})
-			fmt.Printf("unsupport type %T\n", t)
+			fmt.Printf("unsupported type %T\n", t)
 		}
 	}
 
@@ -1039,7 +1039,7 @@ func unittest() {
 			if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
 				fmt.Println("unit-test", val)
 			}
-			fmt.Printf("unsupport type %T\n", t)
+			fmt.Printf("unsupported type %T\n", t)
 		}
 	}
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -195,6 +195,18 @@ func (s *runtimeSuite) TestRuntime(c *C) {
 
 	// Tests for panic
 	c.Assert(testPanic, PanicMatches, "failpoint panic.*")
+
+	err = failpoint.Enable("runtime-test-7", `return`)
+	c.Assert(err, IsNil)
+	ok, val = failpoint.Eval("runtime-test-7")
+	c.Assert(ok, IsTrue)
+	c.Assert(val, Equals, struct{}{})
+
+	err = failpoint.Enable("runtime-test-8", `return()`)
+	c.Assert(err, IsNil)
+	ok, val = failpoint.Eval("runtime-test-8")
+	c.Assert(ok, IsTrue)
+	c.Assert(val, Equals, struct{}{})
 }
 
 func testPanic() {


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```go
package rewriter_test

import (
	"fmt"

	"github.com/pingcap/failpoint"
)

func unittest() {
	type X struct {
		Y int
	}
	func() *X {
		failpoint.Inject("failpoint-name", func(val failpoint.Value) *X {
			return &X{Y: val.(int)}
		})
		return &X{Y: 100}
	}().Y++
}
```

Need to translate to:

```go
package rewriter_test

import (
	"fmt"

	"github.com/pingcap/failpoint"
)

func unittest() {
	type X struct {
		Y int
	}
	func() *X {
		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
			return &X{Y: val.(int)}
		}
		return &X{Y: 100}
	}().Y++
}
```

### What is changed and how it works?

Add support for it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

Related changes
