### PR TITLE
code: support rewrite ExprStmt Init in IfStmt

### DIFF
--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -755,6 +755,62 @@ func unittest() {
 		},
 
 		{
+			filepath: "if-statement-4.go",
+			original: `
+package rewriter_test
+
+import (
+	"fmt"
+
+	"github.com/pingcap/failpoint"
+)
+
+const success = 200
+
+func unittest() {
+	var i int
+	if func(v *int) {
+		failpoint.Inject("failpoint-name", func(val failpoint.Value) {
+			fmt.Println("unit-test", val)
+		})
+		*v = success
+	}(&i); i == success {
+		failpoint.Inject("failpoint-name", func(val failpoint.Value) {
+			fmt.Println("unit-test", val)
+		})
+		fmt.Printf("i = %d success\n", i)
+	}
+}
+`,
+			expected: `
+package rewriter_test
+
+import (
+	"fmt"
+
+	"github.com/pingcap/failpoint"
+)
+
+const success = 200
+
+func unittest() {
+	var i int
+	if func(v *int) {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
+			fmt.Println("unit-test", val)
+		}
+		*v = success
+	}(&i); i == success {
+		if ok, val := failpoint.Eval(_curpkg_("failpoint-name")); ok {
+			fmt.Println("unit-test", val)
+		}
+		fmt.Printf("i = %d success\n", i)
+	}
+}
+`,
+		},
+
+		{
 			filepath: "switch-statement.go",
 			original: `
 package rewriter_test


### PR DESCRIPTION
<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
initialization statement in if statement could be an ast.ExprStmt, such as following code snippet

```go
const success = 200

func Hello() {
        var i int
        if func(v *int) {
                failpoint.Inject("failpoint-name", func(val failpoint.Value) {
                        fmt.Println("unit-test", val)
                })
                *v = success
        }(&i); i == success {
                failpoint.Inject("failpoint-name", func(val failpoint.Value) {
                        fmt.Println("unit-test", val)
                })
                fmt.Printf("i = %d success!\n", i)
        }
}
```

### What is changed and how it works?
add support to it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test