### PR TITLE
code: optimize empty function generated code

### DIFF
--- a/code/expr_rewriter.go
+++ b/code/expr_rewriter.go
@@ -74,7 +74,7 @@ func (r *Rewriter) rewriteInject(call *ast.CallExpr) (bool, ast.Stmt, error) {
 		},
 		Args: []ast.Expr{fpnameExtendCall},
 	}
-	if isNilFunc {
+	if isNilFunc || len(fpbody.Body.List) < 1 {
 		return true, &ast.ExprStmt{X: checkCall}, nil
 	}
 
@@ -162,7 +162,7 @@ func (r *Rewriter) rewriteInjectContext(call *ast.CallExpr) (bool, ast.Stmt, err
 		},
 		Args: []ast.Expr{ctxname, fpnameExtendCall},
 	}
-	if isNilFunc {
+	if isNilFunc || len(fpbody.Body.List) < 1 {
 		return true, &ast.ExprStmt{X: checkCall}, nil
 	}
 

--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -2175,6 +2175,34 @@ func unittest() {
 }
 `,
 		},
+
+		{
+			filepath: "test-empty-body.go",
+			original: `
+package rewriter_test
+
+import (
+	"github.com/pingcap/failpoint"
+)
+
+func unittest() {
+	failpoint.Inject("failpoint-name", func() {})
+	failpoint.Inject("failpoint-name", nil)
+}
+`,
+			expected: `
+package rewriter_test
+
+import (
+	"github.com/pingcap/failpoint"
+)
+
+func unittest() {
+	failpoint.Eval(_curpkg_("failpoint-name"))
+	failpoint.Eval(_curpkg_("failpoint-name"))
+}
+`,
+		},
 	}
 
 	// Create temp files


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Empty function will cause line number inconsistent, e.g

```go
failpoint.Inject("LoadDataSlowDown", func() {})
// GENERATE
if _, ok := failpoint.Eval(_curpkg_("LoadDataSlowDown")); ok {
}

// TO KEEP LINE NUMBER CONSISTENT
failpoint.Inject("LoadDataSlowDown", nil)
// GENERATE
failpoint.Eval(_curpkg_("LoadDataSlowDown"))
```

### What is changed and how it works?

Make empty function and nil function generate same code.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

Related changes
