### PR TITLE
failpoint: change the semantics of 'EvalContext'

### DIFF
--- a/failpoint.go
+++ b/failpoint.go
@@ -54,16 +54,18 @@ func WithHook(ctx context.Context, hook Hook) context.Context {
 
 // EvalContext evaluates a failpoint's value, and calls hook if the context is
 // not nil and contains hook function. It will return the evaluated value and
-// true if the failpoint is active
+// true if the failpoint is active. Always returns false if ctx is nil or context
+// does not contains hook function
 func EvalContext(ctx context.Context, fpname string) (Value, bool) {
-	if ctx != nil {
-		hook := ctx.Value(failpointCtxKey)
-		if hook != nil {
-			h, ok := hook.(Hook)
-			if ok && !h(ctx, fpname) {
-				return nil, false
-			}
-		}
+	if ctx == nil {
+		return nil, false
+	}
+	hook, ok := ctx.Value(failpointCtxKey).(Hook)
+	if !ok {
+		return nil, false
+	}
+	if !hook(ctx, fpname) {
+		return nil, false
 	}
 	return Eval(fpname)
 }

--- a/failpoint_test.go
+++ b/failpoint_test.go
@@ -17,22 +17,33 @@ var _ = Suite(&failpointSuite{})
 type failpointSuite struct{}
 
 func (s *failpointSuite) TestWithHook(c *C) {
+	err := failpoint.Enable("TestWithHook-test-0", "return(1)")
+	c.Assert(err, IsNil)
+
+	val, ok := failpoint.EvalContext(context.Background(), "TestWithHook-test-0")
+	c.Assert(val, IsNil)
+	c.Assert(ok, IsFalse)
+
+	val, ok = failpoint.EvalContext(nil, "TestWithHook-test-0")
+	c.Assert(val, IsNil)
+	c.Assert(ok, IsFalse)
+
 	ctx := failpoint.WithHook(context.Background(), func(ctx context.Context, fpname string) bool {
 		return false
 	})
-	val, ok := failpoint.EvalContext(ctx, "unit-test")
+	val, ok = failpoint.EvalContext(ctx, "unit-test")
 	c.Assert(ok, IsFalse)
 	c.Assert(val, IsNil)
 
 	ctx = failpoint.WithHook(context.Background(), func(ctx context.Context, fpname string) bool {
 		return true
 	})
-	err := failpoint.Enable("TestWithHook-test-1", "return(1)")
+	err = failpoint.Enable("TestWithHook-test-1", "return(1)")
+	c.Assert(err, IsNil)
 	defer func() {
 		err := failpoint.Disable("TestWithHook-test-1")
 		c.Assert(err, IsNil)
 	}()
-	c.Assert(err, IsNil)
 	val, ok = failpoint.EvalContext(ctx, "TestWithHook-test-1")
 	c.Assert(ok, IsTrue)
 	c.Assert(val.(int), Equals, 1)


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Change the semantics of `EvalContext`

### What is changed and how it works?

`EvalContext` will always return false if context is nil or context does not contain hook function.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects


Related changes

