### PR TITLE
code: support rewrite function declaration without body

### DIFF
--- a/code/rewriter.go
+++ b/code/rewriter.go
@@ -557,6 +557,9 @@ func (r *Rewriter) rewriteStmts(stmts []ast.Stmt) error {
 }
 
 func (r *Rewriter) rewriteFuncDecl(fn *ast.FuncDecl) error {
+	if fn.Body == nil {
+		return nil
+	}
 	return r.rewriteStmts(fn.Body.List)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
golang supports function declaration without function body, ref: https://golang.org/ref/spec#Function_declarations
so the following code snippet will fail if we execute `failpoint-ctl` on it

```
package main

import (
    "fmt"
    "github.com/pingcap/failpoint"
    _ "unsafe" // for go:linkname
)

//go:linkname runtimeNano runtime.nanotime
func runtimeNano() int64

func main() {
    failpoint.Inject("failpoint-name", func(val failpoint.Value) {
        fmt.Println("unit-test", val)
    })
    fmt.Printf("nano() runs successfully: %d\n", runtimeNano())
}
```

### What is changed and how it works?
check whether function body is nil when rewriting it 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
