### PR TITLE
code: use format.Node for output that matches gofmt

### DIFF
--- a/code/rewriter.go
+++ b/code/rewriter.go
@@ -16,8 +16,8 @@ package code
 import (
 	"fmt"
 	"go/ast"
+	"go/format"
 	"go/parser"
-	"go/printer"
 	"go/token"
 	"io"
 	"os"
@@ -614,7 +614,7 @@ func (r *Rewriter) RewriteFile(path string) (err error) {
 	}
 
 	if r.output != nil {
-		return printer.Fprint(r.output, fset, file)
+		return format.Node(r.output, fset, file)
 	}
 
 	// Generate binding code
@@ -640,7 +640,7 @@ func (r *Rewriter) RewriteFile(path string) (err error) {
 		return err
 	}
 	defer newFile.Close()
-	return printer.Fprint(newFile, fset, file)
+	return format.Node(newFile, fset, file)
 }
 
 // Rewrite does the rewrite action for specified path. It contains the main steps:

--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -261,6 +261,62 @@ func unittest() {
 		},
 
 		{
+			filepath: "basic-test-format-code.go",
+			original: `
+package rewriter_test
+
+import (
+	"fmt"
+
+	"github.com/pingcap/failpoint"
+)
+
+type CustomStruct struct {
+	FieldWithLongName string
+	Key               int
+	Value             interface{}
+}
+
+func unittest() {
+	failpoint.Inject("failpoint-name", func(val failpoint.Value) {
+		cs := &CustomStruct{
+			FieldWithLongName: "name",
+			Key:               12,
+			Value:             []byte("hello"),
+		}
+		fmt.Println("unit-test", val, cs)
+	})
+}
+`,
+			expected: `
+package rewriter_test
+
+import (
+	"fmt"
+
+	"github.com/pingcap/failpoint"
+)
+
+type CustomStruct struct {
+	FieldWithLongName string
+	Key               int
+	Value             interface{}
+}
+
+func unittest() {
+	if val, ok := failpoint.Eval(_curpkg_("failpoint-name")); ok {
+		cs := &CustomStruct{
+			FieldWithLongName: "name",
+			Key:               12,
+			Value:             []byte("hello"),
+		}
+		fmt.Println("unit-test", val, cs)
+	}
+}
+`,
+		},
+
+		{
 			filepath: "no-body-function.go",
 			original: `
 package rewriter_test
@@ -1410,8 +1466,8 @@ import (
 )
 
 type Iterator struct {
-	count	int
-	max	int
+	count int
+	max   int
 }
 
 func (i *Iterator) Begin(fn func()) int {


### PR DESCRIPTION
<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently we use `printer.Fprint` to print an AST node to output. It calls `Config.Fprint` with default settings, which uses tabs for both indentation and alignment. However gofmt uses tabs for indentation but spaces for alignment.
So in most scenarios `failpoint-ctl enable` will change struct declaration and assignment code which is not relevant to failpoint injection. 

### What is changed and how it works?

use format.Node for output that matches gofmt

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
