### PR TITLE
terms: refine percent mod for term, add related docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,24 @@ An implementation of [failpoints][failpoint] for Golang.
     - `func Return(results ...interface{}) {}`
     - `func Label(label string) {}`
 
+- Supported failpoint environment variable
+
+    failpoint can be enabled by export environment variables with the following patten, which is quite similar to [freebsd failpoint SYSCTL VARIABLES](https://www.freebsd.org/cgi/man.cgi?query=fail)
+
+    ```regexp
+    [<percent>%][<count>*]<type>[(args...)][-><more terms>]
+    ```
+
+    The <type> argument specifies which action to take; it can be one of:
+
+    - off: Take no action (does not trigger failpoint code)
+    - return: Trigger failpoint with specified argument
+    - sleep: Sleep the specified number of milliseconds
+    - panic: Panic
+    - break: Execute gdb and break into debugger
+    - print: Print failpoint path for inject variable
+    - pause: Pause will pause until the failpoint is disabled
+
 ## How to inject a failpoint to your program
 
 - You can call `failpoint.Inject` to inject a failpoint to the call site, where `failpoint-name` is

--- a/terms_test.go
+++ b/terms_test.go
@@ -39,6 +39,9 @@ func TestTermsString(t *testing.T) {
 	}{
 		{`off`, []string{""}},
 		{`2*return("abc")`, []string{"abc", "abc", ""}},
+		{`100%return("abc")`, []string{"abc", "abc", "abc"}},
+		{`100.0%return("abc")`, []string{"abc", "abc", "abc"}},
+		{`100%2*return("abc")`, []string{"abc", "abc", ""}},
 		{`2*return("abc")->1*return("def")`, []string{"abc", "abc", "def", ""}},
 		{`1*return("abc")->return("def")`, []string{"abc", "def", "def"}},
 	}

--- a/terms_test.go
+++ b/terms_test.go
@@ -39,6 +39,7 @@ func TestTermsString(t *testing.T) {
 	}{
 		{`off`, []string{""}},
 		{`2*return("abc")`, []string{"abc", "abc", ""}},
+		{`0%return("abc")`, []string{"", "", ""}},
 		{`100%return("abc")`, []string{"abc", "abc", "abc"}},
 		{`100.0%return("abc")`, []string{"abc", "abc", "abc"}},
 		{`100%2*return("abc")`, []string{"abc", "abc", ""}},


### PR DESCRIPTION
<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Failpoint supports percent and count controller for failpoint execution decision.
The percent module uses random generator from the standard library but doesn't set a random seed, so the executive decision is always the same.
Besides the percent decision doesn't support int value, we can support int value percent such as `20%` to make it more convenient.

### What is changed and how it works?

1. support int value in percent
2. set the random seed to current Unix timestamp to achieve randomness in percent decision
3. add some related docs

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
