### PR TITLE
code: fix token position when rewriting Inject

### DIFF
--- a/code/expr_rewriter.go
+++ b/code/expr_rewriter.go
@@ -69,7 +69,7 @@ func (r *Rewriter) rewriteInject(call *ast.CallExpr) (bool, ast.Stmt, error) {
 
 	checkCall := &ast.CallExpr{
 		Fun: &ast.SelectorExpr{
-			X:   &ast.Ident{call.Pos(), r.failpointName, nil},
+			X:   &ast.Ident{NamePos: call.Pos(), Name: r.failpointName},
 			Sel: ast.NewIdent(evalFunction),
 		},
 		Args: []ast.Expr{fpnameExtendCall},
@@ -157,7 +157,7 @@ func (r *Rewriter) rewriteInjectContext(call *ast.CallExpr) (bool, ast.Stmt, err
 
 	checkCall := &ast.CallExpr{
 		Fun: &ast.SelectorExpr{
-			X:   &ast.Ident{call.Pos(), r.failpointName, nil},
+			X:   &ast.Ident{NamePos: call.Pos(), Name: r.failpointName},
 			Sel: ast.NewIdent(evalCtxFunction),
 		},
 		Args: []ast.Expr{ctxname, fpnameExtendCall},

--- a/code/expr_rewriter.go
+++ b/code/expr_rewriter.go
@@ -69,7 +69,7 @@ func (r *Rewriter) rewriteInject(call *ast.CallExpr) (bool, ast.Stmt, error) {
 
 	checkCall := &ast.CallExpr{
 		Fun: &ast.SelectorExpr{
-			X:   ast.NewIdent(r.failpointName),
+			X:   &ast.Ident{call.Pos(), r.failpointName, nil},
 			Sel: ast.NewIdent(evalFunction),
 		},
 		Args: []ast.Expr{fpnameExtendCall},
@@ -157,7 +157,7 @@ func (r *Rewriter) rewriteInjectContext(call *ast.CallExpr) (bool, ast.Stmt, err
 
 	checkCall := &ast.CallExpr{
 		Fun: &ast.SelectorExpr{
-			X:   ast.NewIdent(r.failpointName),
+			X:   &ast.Ident{call.Pos(), r.failpointName, nil},
 			Sel: ast.NewIdent(evalCtxFunction),
 		},
 		Args: []ast.Expr{ctxname, fpnameExtendCall},

--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -2115,6 +2115,8 @@ import (
 
 func unittest() {
 	failpoint.Inject("failpoint-name", nil)
+
+	failpoint.Inject("failpoint-name", nil)
 }
 `,
 			expected: `
@@ -2127,6 +2129,8 @@ import (
 )
 
 func unittest() {
+	failpoint.Eval(_curpkg_("failpoint-name"))
+
 	failpoint.Eval(_curpkg_("failpoint-name"))
 }
 `,
@@ -2145,6 +2149,8 @@ import (
 
 func unittest() {
 	failpoint.InjectContext(nil, "failpoint-name", nil)
+
+	failpoint.InjectContext(nil, "failpoint-name", nil)
 }
 `,
 			expected: `
@@ -2157,6 +2163,8 @@ import (
 )
 
 func unittest() {
+	failpoint.EvalContext(nil, _curpkg_("failpoint-name"))
+
 	failpoint.EvalContext(nil, _curpkg_("failpoint-name"))
 }
 `,


### PR DESCRIPTION
<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

currently blank line before failpoint injection code will be lost after rewrinting, such as following

there exists a blank line before `failpoint.Inject("test", nil)`
```go
func main() {

        failpoint.Inject("test", nil)
}
```

blank line is lost after rewriting
```go
func main() {
        failpoint.Eval(_curpkg_("test"))
}
```


### What is changed and how it works?
record token position when generating `ast.SelectorExpr` for rewriting `failpoint.Inject`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test