### PR TITLE
code: cancel the restriction of ctx Ident and string literal

### DIFF
--- a/code/expr_rewriter.go
+++ b/code/expr_rewriter.go
@@ -37,9 +37,11 @@ func (r *Rewriter) rewriteInject(call *ast.CallExpr) (bool, ast.Stmt, error) {
 	if len(call.Args) != 2 {
 		return false, nil, fmt.Errorf("failpoint.Inject: expect 2 arguments but got %v in %s", len(call.Args), r.pos(call.Pos()))
 	}
-	fpname, ok := call.Args[0].(*ast.BasicLit)
+	// First argument need not to be a string literal, any string type stuff is ok.
+	// Type safe is convinced by compiler.
+	fpname, ok := call.Args[0].(ast.Expr)
 	if !ok {
-		return false, nil, fmt.Errorf("failpoint.Inject: first argument expect string literal in %s", r.pos(call.Pos()))
+		return false, nil, fmt.Errorf("failpoint.Inject: first argument expect a valid expression in %s", r.pos(call.Pos()))
 	}
 
 	// failpoint.Inject("failpoint-name", nil)
@@ -120,13 +122,17 @@ func (r *Rewriter) rewriteInjectContext(call *ast.CallExpr) (bool, ast.Stmt, err
 		return false, nil, fmt.Errorf("failpoint.InjectContext: expect 3 arguments but got %v in %s", len(call.Args), r.pos(call.Pos()))
 	}
 
-	ctxname, ok := call.Args[0].(*ast.Ident)
+	// Second argument need not to be a identifier, any context type token (e.g. selector) is OK.
+	// Type safe is convinced by compiler.
+	ctxname, ok := call.Args[0].(ast.Expr)
 	if !ok {
-		return false, nil, fmt.Errorf("failpoint.InjectContext: first argument expect context in %s", r.pos(call.Pos()))
+		return false, nil, fmt.Errorf("failpoint.InjectContext: first argument expect context in %s, which must be an expression", r.pos(call.Pos()))
 	}
-	fpname, ok := call.Args[1].(*ast.BasicLit)
+	// Second argument need not to be a string literal, any string type stuff is ok.
+	// Type safe is convinced by compiler.
+	fpname, ok := call.Args[1].(ast.Expr)
 	if !ok {
-		return false, nil, fmt.Errorf("failpoint.InjectContext: second argument expect string literal in %s", r.pos(call.Pos()))
+		return false, nil, fmt.Errorf("failpoint.InjectContext: second argument expect a valid expression in %s", r.pos(call.Pos()))
 	}
 
 	// failpoint.InjectContext("failpoint-name", ctx, nil)


### PR DESCRIPTION
Signed-off-by: Han Fei <hanfei19910905@gmail.com>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`InjectContext` and `Inject` restrict **token-type** of arguments, but I think it's unnecessary. Because **type safe** can be insured by **Go Compiler**, excessive restriction would make test code verbose.

### What is changed and how it works?
So I change the `Indent` and `String Literal` restriction to `Expr` restriction. Indeed, if you can pass compiler check, you cannot fail by failpoint-ctl.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

Related changes
