### PR TITLE
fix deadlock caused by pause

### DIFF
--- a/code/restorer_test.go
+++ b/code/restorer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pingcap/failpoint/code"
 )
 
-func TestNewRestorer(t *testing.T) {
+func TestCode(t *testing.T) {
 	TestingT(t)
 }
 

--- a/code/rewriter_test.go
+++ b/code/rewriter_test.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint/code"
@@ -28,10 +27,6 @@ type filenameComment string
 
 func (c filenameComment) CheckCommentString() string {
 	return string(c)
-}
-
-func TestNewRewriter(t *testing.T) {
-	TestingT(t)
 }
 
 var _ = Suite(&rewriterSuite{path: "tmp/rewrite/"})

--- a/failpoint.go
+++ b/failpoint.go
@@ -74,8 +74,8 @@ func EvalContext(ctx context.Context, fpname string) (Value, bool) {
 // true if the failpoint is active
 func Eval(fpname string) (Value, bool) {
 	failpoints.mu.RLock()
-	defer failpoints.mu.RUnlock()
 	fp, found := failpoints.reg[fpname]
+	failpoints.mu.RUnlock()
 	if !found {
 		return nil, false
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -6,15 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"testing"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 )
-
-func TestHttp(t *testing.T) {
-	TestingT(t)
-}
 
 var _ = Suite(&httpSuite{})
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -3,16 +3,11 @@ package failpoint_test
 import (
 	"io/ioutil"
 	"os"
-	"testing"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 )
-
-func TestNewRestorer(t *testing.T) {
-	TestingT(t)
-}
 
 var _ = Suite(&runtimeSuite{})
 


### PR DESCRIPTION
<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix deadlock cause by failpoint


### What is changed and how it works?
In the current implement, `failpoint.Eval` will hold global lock `failpoints.mu.Rlock` until method finish. But if this is a `Pause` failpoint, this method will finish until `failpoint.Disable` is called. According to [go doc](https://golang.org/pkg/sync/#RWMutex), if other go routine call `failpoint.Enable`(and call failpoints.mu.Lock then), it will deadlock.

By release the global RWLock as soon as possible, we can avoid this problem.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
