### PR TITLE
fix panic for global Eval

### DIFF
--- a/failpoints.go
+++ b/failpoints.go
@@ -251,5 +251,5 @@ func Eval(failpath string) (Value, error) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	return val, nil
+	return val, err
 }


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The `Eval` function returns nil value and error when there is an error occurred(like ErrNotExist), it causes panic when using the value for type conversion.

Code like this would panic when the failpoint is not existed or disabled

```
	if val, err := failpoint.Eval(_curpkg_("FailInjectDemo")); err == nil {
		if val.(bool) {
			fmt.Println("failpoint triggered")
		}
	}
```
Notice this is a critical bug for users who using failpoint.Inject/failpoint.InjectContext, it should be fixed ASAP.

### What is changed and how it works?

Return the error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

