### PR TITLE
suppress to print too may log messages

### DIFF
--- a/failpoints.go
+++ b/failpoints.go
@@ -249,7 +249,10 @@ func EvalContext(ctx context.Context, failpath string) (Value, error) {
 func Eval(failpath string) (Value, error) {
 	val, err := failpoints.Eval(failpath)
 	if err != nil {
-		if err != ErrDisabled && err != ErrNotExist {
+		if err != ErrDisabled &&
+			err != ErrNotExist &&
+			err != ErrNoHook &&
+			err != ErrNoContext {
 			fmt.Println(err)
 		}
 	}

--- a/failpoints.go
+++ b/failpoints.go
@@ -249,7 +249,9 @@ func EvalContext(ctx context.Context, failpath string) (Value, error) {
 func Eval(failpath string) (Value, error) {
 	val, err := failpoints.Eval(failpath)
 	if err != nil {
-		fmt.Println(err)
+		if err != ErrDisabled && err != ErrNotExist {
+			fmt.Println(err)
+		}
 	}
 	return val, err
 }

--- a/failpoints.go
+++ b/failpoints.go
@@ -248,13 +248,12 @@ func EvalContext(ctx context.Context, failpath string) (Value, error) {
 // nil err if the failpoint is active
 func Eval(failpath string) (Value, error) {
 	val, err := failpoints.Eval(failpath)
-	if err != nil {
-		if err != ErrDisabled &&
-			err != ErrNotExist &&
-			err != ErrNoHook &&
-			err != ErrNoContext {
-			fmt.Println(err)
-		}
+	if err != nil &&
+		err != ErrDisabled &&
+		err != ErrNotExist &&
+		err != ErrNoHook &&
+		err != ErrNoContext {
+		fmt.Println(err)
 	}
 	return val, err
 }


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When a failpoint is rewritten without being enabled, a lot log message would be printed.

```
failpoint: failpoint does not exist
failpoint: failpoint does not exist
failpoint: failpoint does not exist
failpoint: failpoint does not exist
```

The messages above are not above.

### What is changed and how it works?

Do not print a message if the error is `ErrNotExist` or `ErrDisabled`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
