### PR TITLE
failpoint: avoid returning the undeclared error

### DIFF
--- a/failpoints.go
+++ b/failpoints.go
@@ -186,11 +186,7 @@ func (fps *Failpoints) Eval(failpath string) (Value, error) {
 		return nil, ErrNotExist
 	}
 
-	val, err := fp.Eval()
-	if err != nil {
-		return nil, fmt.Errorf("%v on %s", err, failpath)
-	}
-	return val, nil
+	return fp.Eval()
 }
 
 // failpoints is the default
@@ -238,8 +234,13 @@ func EvalContext(ctx context.Context, failpath string) (Value, error) {
 	// The package level EvalContext usaully be injected into the users
 	// code, in which case the error can not be handled by the generated
 	// code. We print the error here.
-	if err != nil {
-		fmt.Println(err)
+	if err != nil &&
+		err != ErrDisabled &&
+		err != ErrNotExist &&
+		err != ErrNoHook &&
+		err != ErrNoContext &&
+		err != ErrFiltered {
+		fmt.Printf("%v on %s\n", err, failpath)
 	}
 	return val, err
 }
@@ -252,8 +253,9 @@ func Eval(failpath string) (Value, error) {
 		err != ErrDisabled &&
 		err != ErrNotExist &&
 		err != ErrNoHook &&
-		err != ErrNoContext {
-		fmt.Println(err)
+		err != ErrNoContext &&
+		err != ErrFiltered {
+		fmt.Printf("%v on %s\n", err, failpath)
 	}
 	return val, err
 }

--- a/failpoints.go
+++ b/failpoints.go
@@ -36,17 +36,20 @@ import (
 	"sync"
 )
 
+// FpError is the internal error of failpoint
+type FpError error
+
 var (
 	// ErrNotExist represents a failpoint can not be found by specified name
-	ErrNotExist = fmt.Errorf("failpoint: failpoint does not exist")
+	ErrNotExist FpError = fmt.Errorf("failpoint: failpoint does not exist")
 	// ErrDisabled represents a failpoint is be disabled
-	ErrDisabled = fmt.Errorf("failpoint: failpoint is disabled")
+	ErrDisabled FpError = fmt.Errorf("failpoint: failpoint is disabled")
 	// ErrNoContext returns by EvalContext when the context is nil
-	ErrNoContext = fmt.Errorf("failpoint: no context")
+	ErrNoContext FpError = fmt.Errorf("failpoint: no context")
 	// ErrNoHook returns by EvalContext when there is no hook in the context
-	ErrNoHook = fmt.Errorf("failpoint: no hook")
+	ErrNoHook FpError = fmt.Errorf("failpoint: no hook")
 	// ErrFiltered represents a failpoint is filtered by a hook function
-	ErrFiltered = fmt.Errorf("failpoint: filtered by hook")
+	ErrFiltered FpError = fmt.Errorf("failpoint: filtered by hook")
 )
 
 func init() {
@@ -234,12 +237,7 @@ func EvalContext(ctx context.Context, failpath string) (Value, error) {
 	// The package level EvalContext usaully be injected into the users
 	// code, in which case the error can not be handled by the generated
 	// code. We print the error here.
-	if err != nil &&
-		err != ErrDisabled &&
-		err != ErrNotExist &&
-		err != ErrNoHook &&
-		err != ErrNoContext &&
-		err != ErrFiltered {
+	if err, ok := err.(FpError); !ok && err != nil {
 		fmt.Printf("%v on %s\n", err, failpath)
 	}
 	return val, err
@@ -249,12 +247,7 @@ func EvalContext(ctx context.Context, failpath string) (Value, error) {
 // nil err if the failpoint is active
 func Eval(failpath string) (Value, error) {
 	val, err := failpoints.Eval(failpath)
-	if err != nil &&
-		err != ErrDisabled &&
-		err != ErrNotExist &&
-		err != ErrNoHook &&
-		err != ErrNoContext &&
-		err != ErrFiltered {
+	if err, ok := err.(FpError); !ok && err != nil {
 		fmt.Printf("%v on %s\n", err, failpath)
 	}
 	return val, err

--- a/failpoints_test.go
+++ b/failpoints_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 )
 
@@ -23,7 +24,7 @@ func (s *failpointsSuite) TestFailpoints(c *C) {
 	c.Assert(val.(int), Equals, 1)
 
 	err = fps.Enable("failpoints-test-2", "invalid")
-	c.Assert(err, ErrorMatches, `failpoint: failed to parse \"invalid\" past \"invalid\"`)
+	c.Assert(err, ErrorMatches, `error on failpoints-test-2: failpoint: failed to parse \"invalid\" past \"invalid\"`)
 
 	val, err = fps.Eval("failpoints-test-2")
 	c.Assert(err, NotNil)
@@ -37,7 +38,7 @@ func (s *failpointsSuite) TestFailpoints(c *C) {
 	c.Assert(val, IsNil)
 
 	err = fps.Disable("failpoints-test-1")
-	c.Assert(err, ErrorMatches, `failpoint: failpoint is disabled`)
+	c.Assert(err, ErrorMatches, `error on failpoints-test-1: failpoint: failpoint is disabled`)
 
 	err = fps.Enable("failpoints-test-1", "return(1)")
 	c.Assert(err, IsNil)
@@ -127,7 +128,7 @@ func (s *failpointsSuite) TestFailpoints(c *C) {
 	c.Assert(val, IsNil)
 
 	val, err = fps.Eval("failpoints-test-7")
-	c.Assert(err, Equals, failpoint.ErrNotExist)
+	c.Assert(errors.Cause(err), Equals, failpoint.ErrNotExist)
 	c.Assert(val, IsNil)
 
 	val, err = failpoint.Eval("failpoint-env1")

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pingcap/failpoint
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8
+	github.com/pingcap/errors v0.11.4
 	github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44
 	github.com/stretchr/testify v1.5.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8 h1:USx2/E1bX46VG32FIw034Au6seQ2fY9NEILmNh/UlQg=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44 h1:tB9NOR21++IjLyVx3/PCPhWMwqGNCMQEH96A6dMZ/gc=


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some unuseful messages are printed

```
failpoint is disabled on xxx
```

### What is changed and how it works?

* Return errors directly for `failpoints.Eval`
* Add more checks before printing the log message
* Print error with the failpath

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

