### PR TITLE
Return ErrNotAllowed when a term is not allowed

### DIFF
--- a/failpoints.go
+++ b/failpoints.go
@@ -52,6 +52,8 @@ var (
 	ErrNoHook FpError = fmt.Errorf("failpoint: no hook")
 	// ErrFiltered represents a failpoint is filtered by a hook function
 	ErrFiltered FpError = fmt.Errorf("failpoint: filtered by hook")
+	// ErrNotAllowed represents a failpoint can not be executed this time
+	ErrNotAllowed FpError = fmt.Errorf("failpoint: not allowed")
 )
 
 func init() {

--- a/failpoints_test.go
+++ b/failpoints_test.go
@@ -88,7 +88,7 @@ func (s *failpointsSuite) TestFailpoints(c *C) {
 		c.Assert(val.(int), Equals, 5)
 	}
 	val, err = fps.Eval("failpoints-test-5")
-	c.Assert(err, IsNil)
+	c.Assert(errors.Cause(err), Equals, failpoint.ErrNotAllowed)
 	c.Assert(val, IsNil)
 
 	points := map[string]struct{}{}
@@ -124,7 +124,7 @@ func (s *failpointsSuite) TestFailpoints(c *C) {
 		c.Assert(val.(int), Equals, 20)
 	}
 	val, err = fps.Eval("failpoints-test-6")
-	c.Assert(err, IsNil)
+	c.Assert(errors.Cause(err), Equals, failpoint.ErrNotAllowed)
 	c.Assert(val, IsNil)
 
 	val, err = fps.Eval("failpoints-test-7")

--- a/terms.go
+++ b/terms.go
@@ -115,7 +115,7 @@ func (t *terms) eval() (Value, error) {
 			return term.do()
 		}
 	}
-	return nil, nil
+	return nil, ErrNotAllowed
 }
 
 // split terms from a -> b -> ... into [a, b, ...]


### PR DESCRIPTION
Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Return an error when the term is not allowed

For example: `1*return(true)` should trigger the fail point once and it returns `ErrNotAllowed` if `Eval` is called multiple times.

### What is changed and how it works?

Return `ErrNotAllowed` when a term is not allowed to evaluate.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

