### PR TITLE
failpoint: fix go failpoint data race

### DIFF
--- a/failpoint.go
+++ b/failpoint.go
@@ -101,11 +101,11 @@ func (fp *Failpoint) Disable() error {
 // Eval evaluates a failpoint's value, It will return the evaluated value or
 // an error if the failpoint is disabled or failed to eval
 func (fp *Failpoint) Eval() (Value, error) {
+	fp.mu.RLock()
+	defer fp.mu.RUnlock()
 	if fp.t == nil {
 		return nil, ErrDisabled
 	}
-	fp.mu.RLock()
-	defer fp.mu.RUnlock()
 	v, err := fp.t.eval()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix go failpoint data race in TiDB test case.
1: when `*CustomParallelSuiteFlag = true` is set, the tests in different `Suite` will run parallelly.
2: when a test arrived `Enable()`, when another arrived `Eval()` will cause data race in failpoint.

For more detail: see https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_unit_test/detail/tidb_ghpr_unit_test/38125/pipeline/

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code