### PR TITLE
failpoint: don't wrap error when failpoint doesn't exist

### DIFF
--- a/failpoints.go
+++ b/failpoints.go
@@ -207,12 +207,12 @@ func (fps *Failpoints) Eval(failpath string) (Value, error) {
 	fp, found := fps.reg[failpath]
 	fps.mu.RUnlock()
 	if !found {
-		return nil, errors.Wrapf(ErrNotExist, "error on %s", failpath)
+		return nil, ErrNotExist
 	}
 
 	val, err := fp.Eval()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error on %s", failpath)
+		return nil, err
 	}
 	return val, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Failpoint! Please read the [CONTRIBUTING](https://github.com/pingcap/failpoint/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

For https://github.com/pingcap/tidb/issues/32767

### What is changed and how it works?

Avoid the errors.Wrap, it will capture the goroutine stack and cause perfromance issue.

Actually, the error is ignored when the failpoint doesn't exist.

Run TiDB CI before and after this simple change:

```
run all tasks takes 3m52.775268946s

run all tasks takes 2m51.273945186s
```



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note