### PR TITLE
failpoint.Disable should be idempotent

### DIFF
--- a/failpoint.go
+++ b/failpoint.go
@@ -82,21 +82,18 @@ func (fp *Failpoint) EnableWith(inTerms string, action func() error) error {
 }
 
 // Disable stops a failpoint
-func (fp *Failpoint) Disable() error {
+func (fp *Failpoint) Disable() {
 	select {
 	case <-fp.waitChan:
-		return ErrDisabled
+		// already disabled
+		return
 	default:
 		close(fp.waitChan)
 	}
 
 	fp.mu.Lock()
 	defer fp.mu.Unlock()
-	if fp.t == nil {
-		return ErrDisabled
-	}
 	fp.t = nil
-	return nil
 }
 
 // Eval evaluates a failpoint's value, It will return the evaluated value or

--- a/failpoints.go
+++ b/failpoints.go
@@ -140,12 +140,9 @@ func (fps *Failpoints) Disable(failpath string) error {
 
 	fp := fps.reg[failpath]
 	if fp == nil {
-		return errors.Wrapf(ErrDisabled, "error on %s", failpath)
+		return errors.Wrapf(ErrNotExist, "error on %s", failpath)
 	}
-	err := fp.Disable()
-	if err != nil {
-		return errors.Wrapf(err, "error on %s", failpath)
-	}
+	fp.Disable()
 	return nil
 }
 

--- a/failpoints_test.go
+++ b/failpoints_test.go
@@ -49,7 +49,7 @@ func TestFailpoints(t *testing.T) {
 	require.Nil(t, val)
 
 	err = fps.Disable("failpoints-test-1")
-	require.EqualError(t, err, `error on failpoints-test-1: failpoint: failpoint is disabled`)
+	require.NoError(t, err)
 
 	err = fps.Enable("failpoints-test-1", "return(1)")
 	require.NoError(t, err)


### PR DESCRIPTION
This closes #75.

It will change the interface of `failpoint.Disable` but not `failpoints.Disable` and thus almost usage should be fine.

`failpoint.Disable` now never return an error because it always succeeds now. If we want to be backward compatible on compilation (but we don't even do a semver release), we can keep the interface and `return nil` always.

Signed-off-by: tison <wander4096@gmail.com>