### PR TITLE
fix: failpoint-toolexec not working on Windows

### DIFF
--- a/failpoint-toolexec/main.go
+++ b/failpoint-toolexec/main.go
@@ -37,7 +37,7 @@ func main() {
 	goCmd, buildArgs := os.Args[1], os.Args[2:]
 	goCmdBase := filepath.Base(goCmd)
 	if runtime.GOOS == "windows" {
-		goCmdBase = strings.TrimSuffix(goCmd, ".exe")
+		goCmdBase = strings.TrimSuffix(goCmdBase, ".exe")
 	}
 
 	if strings.ToLower(goCmdBase) == "compile" {


### PR DESCRIPTION
## Summary

`failpoint-toolexec` silently skips all failpoint injection on Windows due to a typo on line 40 of `failpoint-toolexec/main.go`.

**Bug**: `strings.TrimSuffix(goCmd, ".exe")` operates on the full path (`C:\...\compile.exe` → `C:\...\compile`) instead of the base name. The comparison `goCmdBase == "compile"` always evaluates to `false`, so the compile command is never intercepted.

**Fix**: `strings.TrimSuffix(goCmdBase, ".exe")`

## Reproduction

On Windows, `failpoint.Inject` markers are never rewritten when using `-toolexec failpoint-toolexec`. Tests that rely on failpoint injection silently pass without actually injecting errors.

Verified by logging the values inside the toolexec binary:
```
goCmd   = C:\Users\...\compile.exe
Base    = compile.exe
orig    = C:\Users\...\compile    match=false   ← bug
fixed   = compile                 match=true    ← fix
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)